### PR TITLE
CI: fix failing build — harden Contentful client and rewrite workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,39 @@
-name: Generate a build and push to another branch
+name: CI
 
 on:
   push:
     branches:
-      - master # The branch name your are commit the new changes
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and Push
+    name: Build and Lint
     steps:
-      - name: git-checkout
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Install all dependencies
-        run: npm install
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
 
       - name: Build
-        run: npm run build # The build command of your project
-
-      - name: Push
-        uses: s0/git-publish-subdir-action@develop
+        run: npm run build
         env:
-          REPO: self
-          BRANCH: master # The branch name where you want to push the assets
-          FOLDER: master # The directory where your assets are generated
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub will automatically add this - you don't need to bother getting a token
-          MESSAGE: "Build: ({sha}) {msg}" # The commit message
+          NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ${{ secrets.NEXT_PUBLIC_CONTENTFUL_SPACE_ID }}
+          NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ${{ secrets.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN }}
+          GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
+          GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
+          GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -1,27 +1,5 @@
-import { createClient } from "contentful";
+import { createClient, type ContentfulClientApi } from "contentful";
 import { Document, BLOCKS } from "@contentful/rich-text-types";
-import type {
-  ContentTypeCollection,
-} from "contentful";
-
-// Validate environment variables
-function validateEnvVariables() {
-  const spaceId = process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID;
-  const accessToken = process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN;
-
-  if (!spaceId) {
-    throw new ContentfulError(
-      "Missing NEXT_PUBLIC_CONTENTFUL_SPACE_ID environment variable"
-    );
-  }
-  if (!accessToken) {
-    throw new ContentfulError(
-      "Missing NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN environment variable"
-    );
-  }
-
-  return { spaceId, accessToken };
-}
 
 const defaultDocument: Document = {
   nodeType: BLOCKS.DOCUMENT,
@@ -113,16 +91,35 @@ class ContentfulError extends Error {
   }
 }
 
-// Initialize Contentful client with validated environment variables
-const { spaceId, accessToken } = validateEnvVariables();
+// Lazy client: missing env vars don't crash module load (important for CI
+// builds without Contentful secrets). Consumers get null and fail gracefully.
+function buildContentfulClient(): ContentfulClientApi<undefined> | null {
+  const spaceId = process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID;
+  const accessToken = process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN;
 
-export const contentfulClient = createClient({
-  space: spaceId,
-  accessToken: accessToken,
-  environment: "master",
-});
+  if (!spaceId || !accessToken) {
+    if (typeof window === 'undefined') {
+      console.warn(
+        'Contentful client not initialized: NEXT_PUBLIC_CONTENTFUL_SPACE_ID or NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN is missing.'
+      );
+    }
+    return null;
+  }
+
+  return createClient({
+    space: spaceId,
+    accessToken,
+    environment: 'master',
+  });
+}
+
+export const contentfulClient = buildContentfulClient();
 
 export async function getBlogPosts(): Promise<BlogPost[]> {
+  if (!contentfulClient) {
+    return [];
+  }
+
   try {
     const response = await contentfulClient.getEntries<BlogPostSkeleton>({
       content_type: 'blogPost',
@@ -173,6 +170,10 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
 export async function getBlogPost(slug: string): Promise<BlogPost | null> {
   if (!slug) {
     throw new ContentfulError("Blog post slug is required");
+  }
+
+  if (!contentfulClient) {
+    return null;
   }
 
   try {


### PR DESCRIPTION
## Summary

The `publish.yml` workflow added in `686ed03` is failing every push to `master` (including the recent merge of PR #40 and the dependabot merges). Two bugs:

1. **No env vars passed to `npm run build`** — `contentful.ts` threw `ContentfulError: Missing NEXT_PUBLIC_CONTENTFUL_SPACE_ID environment variable` at module load during static prerender of `/`, failing the build.
2. **The `s0/git-publish-subdir-action` step was misconfigured** — `BRANCH: master FOLDER: master` would push the source branch back onto itself. Even with envs fixed this would loop, and this site has Next.js API routes (the contact form) so it can't be hosted from a static branch anyway. Vercel handles real deployments.

## Changes

**`src/lib/contentful.ts`** — replaced throw-on-missing-env `validateEnvVariables()` with a lazy `buildContentfulClient()` that returns `null` when envs are absent. `getBlogPosts()` returns `[]` and `getBlogPost()` returns `null` when the client is null, so builds succeed without Contentful credentials.

**`.github/workflows/publish.yml`** — converted to a CI check (build + lint on push and PR):
- Uses `actions/checkout@v4` and `actions/setup-node@v4` with npm cache
- Runs `npm ci` instead of `npm install`
- Runs `npm run lint`
- References all six secrets via `env:` so a full build runs when secrets are set in repo settings
- Removed the broken `s0/git-publish-subdir-action` push step

## Verification

Confirmed locally that `npm run build` succeeds with **all six env vars unset** (simulating CI without secrets). The `Contentful client not initialized` warning logs once and the build completes; the home page pre-renders with an empty blog list.

## Test plan

- [ ] GitHub Actions `Build and Lint` job passes on this PR
- [ ] After merge: future pushes to master no longer fail in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)